### PR TITLE
Align configuration docs with dynamic SADC schedule

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,10 +1,19 @@
-defaults:
-  - _self_
-  - curriculum: default
+# Base training configuration for the NAICS SADC pipeline
 
 # Experiment identification
-experiment_name: ${curriculum.name}
+experiment_name: sadc_default
 seed: 42
+
+# Curriculum scheduler configuration (Structure-Aware Dynamic Curriculum)
+curriculum:
+  phase1_end: 0.3  # Structural initialization cutoff (fraction of epochs)
+  phase2_end: 0.7  # Geometric refinement cutoff (fraction of epochs)
+  phase3_end: 1.0  # False negative mitigation cutoff (fraction of epochs)
+  tree_distance_alpha: 1.5  # Inverse-distance weighting exponent for negatives
+  sibling_distance_threshold: 2.0  # Distance threshold for sibling masking
+  fn_curriculum_start_epoch: 10  # Epoch to begin false-negative elimination
+  fn_cluster_every_n_epochs: 5  # How often to refresh clustering during Phase 3
+  fn_num_clusters: 500  # Number of clusters used for false-negative elimination
 
 # Paths
 dirs:
@@ -20,13 +29,13 @@ data_loader:
   batch_size: 12
   num_workers: 4
   val_split: 0.05
-  
+
   tokenization:
     tokenizer_name: sentence-transformers/all-MiniLM-L6-v2
     max_length: 512
     padding: max_length
     truncation: true
-  
+
   streaming:
     descriptions_parquet: ./data/naics_descriptions.parquet
     triplets_parquet: ./data/naics_training_pairs
@@ -41,19 +50,19 @@ data_loader:
 # Model configuration
 model:
   base_model_name: sentence-transformers/all-MiniLM-L6-v2
-  
+
   lora:
     r: 8
     alpha: 16
     dropout: 0.1
-  
+
   moe:
     num_experts: 4
     top_k: 2
     hidden_dim: 768
     load_balancing_coef: 0.01
-  
-  eval_sample_size: 300  
+
+  eval_sample_size: 300
   eval_every_n_epochs: 1
 
 # Loss configuration
@@ -71,7 +80,7 @@ training:
   weight_decay: 0.01
   warmup_steps: 500
   use_warmup_cosine: false  # Set to true for large training jobs with many epochs
-  
+
   trainer:
     max_epochs: 15  # Reduced to prevent unnecessary training
     accelerator: auto

--- a/docs/text_training.md
+++ b/docs/text_training.md
@@ -1,495 +1,171 @@
 # Training Guide
 
-This guide covers how to train the NAICS Hyperbolic Embedding System using the contrastive learning pipeline. The system supports single-stage training, sequential curriculum training, and chain-based training with checkpoint resumption.
+This guide explains how to train the NAICS Hyperbolic Embedding System with the dynamic Structure-Aware Dynamic Curriculum (SADC) scheduler. The current workflow uses a single configuration file (`conf/config.yaml`) to control model, data, trainer, and curriculum settings.
 
 ## Table of Contents
 
 1. [Quick Start](#quick-start)
-2. [Single-Stage Training](#single-stage-training)
-3. [Sequential Curriculum Training](#sequential-curriculum-training)
-4. [Chain Configuration](#chain-configuration)
-5. [Resuming from Checkpoints](#resuming-from-checkpoints)
-6. [Configuration Files](#configuration-files)
-7. [Common Workflows](#common-workflows)
-8. [Troubleshooting](#troubleshooting)
+2. [Training Command](#training-command)
+3. [Dynamic SADC Schedule](#dynamic-sadc-schedule)
+4. [Resuming from Checkpoints](#resuming-from-checkpoints)
+5. [Configuration Reference](#configuration-reference)
+6. [Common Workflows](#common-workflows)
+7. [Troubleshooting](#troubleshooting)
+8. [Distributed Training](#distributed-training)
 
 ---
 
 ## Quick Start
 
-### List Available Curricula
+Run the recommended dynamic curriculum training loop:
 
 ```bash
-uv run naics-embedder train --list-curricula
+uv run naics-embedder train
 ```
 
-### Run a Single Training Stage
+Inspect the active configuration, including SADC phase boundaries:
 
 ```bash
-uv run naics-embedder train --curriculum 01_stage
+uv run naics-embedder tools config
 ```
 
-### Run Sequential Training with Chain Config
-
-```bash
-uv run naics-embedder train-curriculum --chain chain_default
-```
-
----
-
-## Single-Stage Training
-
-Train a single curriculum stage with a specific configuration.
-
-### Basic Usage
+Apply ad-hoc overrides without editing YAML:
 
 ```bash
 uv run naics-embedder train \
-  --curriculum 01_stage \
-  --config conf/config.yaml
-```
-
-### With Configuration Overrides
-
-Override specific parameters without editing config files:
-
-```bash
-uv run naics-embedder train \
-  --curriculum 01_stage \
   training.learning_rate=1e-4 \
-  data_loader.batch_size=8 \
-  training.trainer.max_epochs=15
+  data_loader.batch_size=16 \
+  curriculum.phase2_end=0.65
 ```
 
-### Command Options
+---
 
-- `--curriculum, -c`: Curriculum config name (e.g., `01_stage`, `default`)
-- `--config`: Path to base config YAML file (default: `conf/config.yaml`)
-- `--list-curricula`: List all available curriculum configs and exit
-- Overrides: Space-separated key-value pairs using dot notation
+## Training Command
 
-### Example: Training with Custom Learning Rate
+The `train` command orchestrates data loading, dynamic curriculum scheduling, and model optimization. It reads `conf/config.yaml` and applies any command-line overrides.
 
 ```bash
+uv run naics-embedder train [OPTIONS] [OVERRIDES...]
+```
+
+**Options**
+
+- `--config PATH` — Path to the base config (default: `conf/config.yaml`).
+- `--ckpt-path PATH` — Resume from a checkpoint (`last` auto-detects the latest checkpoint in `checkpoints/<experiment_name>`).
+- `--skip-validation` — Skip pre-flight validation of data files and tokenization cache.
+- `OVERRIDES...` — Dot-notation overrides (e.g., `training.learning_rate=5e-5 curriculum.phase1_end=0.25`).
+
+**Examples**
+
+```bash
+# Resume from the last checkpoint
+uv run naics-embedder train --ckpt-path last
+
+# Start fresh with a shorter run
+uv run naics-embedder train training.trainer.max_epochs=8
+
+# Run with a different experiment name and output folder
 uv run naics-embedder train \
-  --curriculum 02_stage \
-  training.learning_rate=5e-5 \
-  training.trainer.max_epochs=20
+  experiment_name=sadc_ablation \
+  dirs.output_dir=./outputs/ablation
 ```
+
+> **Legacy sequential training**: The `train-seq` command is kept for historical multi-stage experiments. Modern runs should rely on the single dynamic SADC schedule.
 
 ---
 
-## Sequential Curriculum Training
+## Dynamic SADC Schedule
 
-Train multiple curriculum stages sequentially, with each stage building on the previous one's learned representations.
+SADC is a three-phase scheduler embedded in `curriculum.*` fields within `conf/config.yaml`:
 
-### Basic Usage
+- **Phase 1: Structural Initialization (`phase1_end`)**
+  - Masks siblings and weights negatives by inverse tree distance (`tree_distance_alpha`, `sibling_distance_threshold`).
+- **Phase 2: Geometric Refinement (`phase2_end`)**
+  - Enables Lorentzian hard-negative mining and router-guided sampling for the MoE encoder.
+- **Phase 3: False Negative Mitigation (`phase3_end`)**
+  - Activates clustering-based false-negative elimination, refreshed every `fn_cluster_every_n_epochs` epochs using `fn_num_clusters` clusters, starting at `fn_curriculum_start_epoch`.
 
-Train all default stages (01-05) sequentially:
-
-```bash
-uv run naics-embedder train-curriculum
-```
-
-### Specify Stages Manually
-
-```bash
-uv run naics-embedder train-curriculum \
-  --curricula 01_stage,02_stage,03_stage
-```
-
-### With Custom Config
-
-```bash
-uv run naics-embedder train-curriculum \
-  --curricula 01_stage,02_stage,03_stage \
-  --config conf/config.yaml
-```
-
-### Command Options
-
-- `--curricula, -c`: Comma-separated list of curriculum stages
-- `--chain`: Chain configuration file (overrides `--curricula`)
-- `--config`: Path to base config YAML file
-- `--resume`: Resume from last checkpoint if available (default: `true`)
-- `--from-checkpoint`: Resume from a specific checkpoint (see [Resuming from Checkpoints](#resuming-from-checkpoints))
-
-### How Sequential Training Works
-
-1. **Stage 1**: Trains from scratch (random initialization)
-2. **Stage 2**: Loads the best checkpoint from Stage 1
-3. **Stage 3**: Loads the best checkpoint from Stage 2
-4. And so on...
-
-Each stage uses the **learned encoder weights** from the previous stage, allowing progressive refinement of the embedding space.
-
----
-
-## Chain Configuration
-
-Chain configurations allow you to define a sequence of stages with stage-specific training parameter overrides (e.g., `max_epochs`, `learning_rate`).
-
-### Chain Config Format
-
-Create a chain config file in `conf/text_curriculum/`:
-
-```yaml
-chain_name: progressive_difficulty
-
-stages:
-  - name: 01_stage
-    max_epochs: 5
-    learning_rate: 2e-4
-  - name: 02_stage  
-    max_epochs: 8
-    learning_rate: 1e-4
-  - name: 03_stage
-    max_epochs: 10
-    learning_rate: 5e-5
-```
-
-### Using a Chain Config
-
-```bash
-uv run naics-embedder train-curriculum --chain chain_default
-```
-
-This will:
-
-1. Load the chain configuration
-2. Run stages in order: `01_stage`, `02_stage`, `03_stage`
-3. Apply stage-specific overrides:
-   - Stage 01: `max_epochs=5`, `learning_rate=2e-4`
-   - Stage 02: `max_epochs=8`, `learning_rate=1e-4`
-   - Stage 03: `max_epochs=10`, `learning_rate=5e-5`
-
-### Chain Config Fields
-
-- `chain_name`: Name of the training chain (for logging/identification)
-- `stages`: List of stage configurations
-  - `name`: Curriculum stage name (must match a file in `conf/text_curriculum/`)
-  - `max_epochs` (optional): Override max epochs for this stage
-  - `learning_rate` (optional): Override learning rate for this stage
-
-**Note**: If `max_epochs` or `learning_rate` are not specified, the values from the base config or curriculum config are used.
+Adjust these boundaries or cadences via YAML or command-line overrides to tailor the schedule to your run length.
 
 ---
 
 ## Resuming from Checkpoints
 
-The training system supports resuming from checkpoints in several ways:
+Checkpoints are stored under `checkpoints/<experiment_name>/`.
 
-### 1. Automatic Resumption (Default)
-
-When running sequential training, the system automatically resumes from the previous stage's checkpoint:
-
-```bash
-uv run naics-embedder train-curriculum --curricula 01_stage,02_stage,03_stage
-```
-
-Stage 2 will automatically load Stage 1's best checkpoint, and Stage 3 will load Stage 2's best checkpoint.
-
-### 2. Resume from Specific Stage
-
-Resume training from a specific stage's checkpoint by stage name:
-
-```bash
-uv run naics-embedder train-curriculum \
-  --curricula 04_stage \
-  --from-checkpoint 03_stage
-```
-
-This will:
-
-- Search for the best checkpoint from `03_stage` in any previous sequential run
-- Use that checkpoint to initialize training for `04_stage`
-
-### 3. Resume from Specific Checkpoint File
-
-Resume from an exact checkpoint file path:
-
-```bash
-uv run naics-embedder train-curriculum \
-  --curricula 04_stage \
-  --from-checkpoint checkpoints/sequential_01-02-03/03_stage/03_stage-epoch=10-val_loss=0.1234.ckpt
-```
-
-### 4. Re-run a Stage with Different Parameters
-
-Re-train a stage starting from its own previous checkpoint:
-
-```bash
-# First, modify 03_stage.yaml or use overrides
-uv run naics-embedder train-curriculum \
-  --curricula 03_stage \
-  --from-checkpoint 03_stage \
-  training.learning_rate=1e-5
-```
-
-### Checkpoint Discovery
-
-When using `--from-checkpoint` with a stage name (not a file path), the system:
-
-1. Searches all `sequential_*/` directories in the checkpoint folder
-2. Finds checkpoints from the specified stage
-3. Selects the checkpoint with the **lowest validation loss** (best model)
-4. Uses that checkpoint to resume training
-
-### Checkpoint Directory Structure
-
-Checkpoints are organized as follows:
-
-```
-checkpoints/
-  sequential_01-02-03/          # Sequential run identifier
-    01_stage/
-      01_stage-epoch=05-val_loss=0.1234.ckpt
-      last.ckpt
-    02_stage/
-      02_stage-epoch=08-val_loss=0.0987.ckpt
-      last.ckpt
-    03_stage/
-      03_stage-epoch=10-val_loss=0.0876.ckpt
-      last.ckpt
-```
+- **Auto-resume**: `--ckpt-path last` loads the most recent checkpoint for the configured experiment.
+- **Explicit path**: Point `--ckpt-path` to any `.ckpt` file to warm-start a new run.
+- **Fresh start**: Omit `--ckpt-path` to ignore existing checkpoints.
 
 ---
 
-## Configuration Files
+## Configuration Reference
 
-### Base Configuration (`conf/config.yaml`)
+All settings live in `conf/config.yaml`:
 
-Main training configuration including:
+- **Experiment**: `experiment_name`, `seed`.
+- **Curriculum**: `curriculum.phase{1,2,3}_end`, `tree_distance_alpha`, `sibling_distance_threshold`, `fn_curriculum_start_epoch`, `fn_cluster_every_n_epochs`, `fn_num_clusters`.
+- **Paths**: `dirs.*` for data, logs, outputs, checkpoints, and docs.
+- **Data Loader**: Batch size, workers, validation split, and tokenization/streaming inputs.
+- **Model**: Base encoder, LoRA, and MoE settings; evaluation cadence.
+- **Loss**: Temperature, curvature, margins, and hierarchy/rank/radius regularization weights.
+- **Training**: Optimizer hyperparameters and Lightning trainer settings.
 
-- Model architecture (LoRA, MoE, etc.)
-- Training hyperparameters (learning rate, weight decay, etc.)
-- Data loader settings (batch size, num workers, etc.)
-- Trainer settings (max epochs, precision, etc.)
-
-### Curriculum Configuration (`conf/text_curriculum/*.yaml`)
-
-Stage-specific curriculum settings:
-
-- `name`: Curriculum name
-- `anchor_level`: Filter anchors by hierarchy level
-- `positive_level`: Filter positives by hierarchy level
-- `positive_relation`: Filter positives by relation type
-- `n_positives`: Number of positive samples per anchor
-- `n_negatives`: Number of negative samples per anchor
-
-### Example Curriculum Config
-
-```yaml
-name: 01_stage
-
-# Anchor filtering
-anchor_level: [2, 3]
-relation_margin: null
-distance_margin: null
-
-# Positive filtering
-positive_level: [2, 3]
-positive_relation: [1, 2]
-positive_distance: null
-
-# Negative sampling
-negative_level: null
-negative_relation: null
-negative_distance: null
-
-# Sample counts
-n_positives: 64
-n_negatives: 24
-```
+Use `tools config` to render a condensed view of these values.
 
 ---
 
 ## Common Workflows
 
-### Workflow 1: Full Chain Training
-
-Train a complete chain from scratch:
+**Complete data pipeline then train**
 
 ```bash
-uv run naics-embedder train-curriculum --chain chain_default
+uv run naics-embedder data all
+uv run naics-embedder train
 ```
 
-### Workflow 2: Continue Training After a Chain
-
-After running `chain_default` (stages 01-03), continue with stage 04:
+**Memory-aware tuning**
 
 ```bash
-uv run naics-embedder train-curriculum \
-  --curricula 04_stage \
-  --from-checkpoint 03_stage
+uv run naics-embedder tools gpu --auto
+uv run naics-embedder train data_loader.batch_size=<suggested>
 ```
 
-### Workflow 3: Experiment with Different Parameters
-
-Re-run a stage with different learning rate:
-
-```bash
-uv run naics-embedder train-curriculum \
-  --curricula 02_stage \
-  --from-checkpoint 01_stage \
-  training.learning_rate=5e-5 \
-  training.trainer.max_epochs=15
-```
-
-### Workflow 4: Custom Sequential Run
-
-Run a custom sequence of stages:
-
-```bash
-uv run naics-embedder train-curriculum \
-  --curricula 01_stage,03_stage,05_stage
-```
-
-### Workflow 5: Single Stage with Overrides
-
-Train a single stage with parameter overrides:
+**Adjust curriculum boundaries for shorter runs**
 
 ```bash
 uv run naics-embedder train \
-  --curriculum 01_stage \
-  training.learning_rate=1e-4 \
-  data_loader.batch_size=16 \
-  training.trainer.max_epochs=10
+  training.trainer.max_epochs=8 \
+  curriculum.phase1_end=0.2 \
+  curriculum.phase2_end=0.55
 ```
 
 ---
 
 ## Troubleshooting
 
-### Checkpoint Not Found
-
-**Problem**: `--from-checkpoint` can't find a checkpoint
-
-**Solutions**:
-
-1. Verify the checkpoint file exists:
-
-   ```bash
-   ls -la checkpoints/sequential_*/03_stage/*.ckpt
-   ```
-
-2. Use the full checkpoint file path instead of stage name
-3. Check that the checkpoint directory structure matches expected format
-
-### Stage Already Complete
-
-**Problem**: Training skips a stage because it's already complete
-
-**Solution**: This is expected behavior when `--resume` is enabled. To re-train:
-
-- Delete the checkpoint directory for that stage, or
-- Use `--resume false` to force re-training
-
-### Out of Memory
-
-**Problem**: GPU runs out of memory during training
-
-**Solutions**:
-
-1. Reduce batch size: `data_loader.batch_size=4`
-2. Increase gradient accumulation: `training.trainer.accumulate_grad_batches=8`
-3. Reduce number of positives/negatives in curriculum config
-4. Use mixed precision: `training.trainer.precision=16-mixed` (already default)
-5. **For Distributed Training**: Monitor global batch memory usage in TensorBoard
-   - Check `train/global_batch/global_negatives_memory_mb` metric
-   - If memory is high, reduce `n_negatives` in curriculum config
-
-### Learning Rate Too High/Low
-
-**Problem**: Training diverges or converges too slowly
-
-**Solutions**:
-
-1. Use chain config to set stage-specific learning rates
-2. Use command-line overrides: `training.learning_rate=1e-5`
-3. Adjust in base config file
-
-### Model Not Improving
-
-**Problem**: Validation loss plateaus or increases
-
-**Solutions**:
-
-1. Check curriculum config - may need more diverse positives/negatives
-2. Reduce learning rate for later stages
-3. Increase training epochs
-4. Check data quality and filtering settings
-
----
-
-## Best Practices
-
-1. **Start with Chain Configs**: Use chain configurations for reproducible multi-stage training
-2. **Monitor TensorBoard**: Check training progress and metrics:
-
-   ```bash
-   tensorboard --logdir outputs/
-   ```
-
-3. **Save Checkpoints**: Always keep checkpoints from each stage for flexibility
-4. **Use Stage-Specific Learning Rates**: Gradually reduce learning rate across stages
-5. **Validate Checkpoints**: Test that checkpoints load correctly before long training runs
-6. **Document Experiments**: Keep notes on which configs/checkpoints produced best results
+- **Out of memory**: Lower `data_loader.batch_size`, increase `training.trainer.accumulate_grad_batches`, or reduce `fn_num_clusters` to lighten Phase 3 clustering.
+- **Slow convergence**: Shorten `fn_curriculum_start_epoch` so false-negative mitigation starts earlier; reduce `training.learning_rate` if loss oscillates.
+- **Scheduler transitions**: If phases feel too short or long, adjust `curriculum.phase*` boundaries so each phase covers the desired fraction of epochs.
 
 ---
 
 ## Distributed Training
 
-The system supports multi-GPU distributed training with automatic global batch sampling for improved hard negative mining.
-
-### Enabling Distributed Training
-
-Configure the number of GPUs in your config file:
+Enable multi-GPU runs by updating the trainer configuration:
 
 ```yaml
 training:
   trainer:
-    devices: 4  # Number of GPUs to use
-    accelerator: 'gpu'
+    devices: 4
+    accelerator: gpu
+    precision: "16-mixed"
 ```
 
-Or override via command line:
+Or via overrides:
 
 ```bash
-uv run naics-embedder train \
-  --curriculum 01_text \
-  training.trainer.devices=4
+uv run naics-embedder train training.trainer.devices=4 training.trainer.accelerator=gpu
 ```
 
-### Global Batch Sampling
-
-When distributed training is enabled with hard negative mining, the system automatically:
-
-1. **Gathers negatives from all GPUs** using `torch.distributed.all_gather`
-2. **Selects hard negatives from the global pool** (not just local batch)
-3. **Preserves gradient flow** through the all_gather operation
-4. **Monitors memory usage** and logs metrics to TensorBoard
-
-**Benefits:**
-
-- **Larger Negative Pool**: Access to negatives from all GPUs
-- **Better Hard Negatives**: More likely to find meaningful "Cousin" relationships
-- **Improved Training**: Higher quality negative samples lead to better representations
-
-**Memory Considerations:**
-
-- Global negatives: ~9MB per GPU (for batch_size=32, world_size=4, k_negatives=24)
-- Similarity matrix: ~393KB per batch
-- Monitor via TensorBoard: `train/global_batch/global_negatives_memory_mb`
-
-### Monitoring Distributed Training
-
-TensorBoard provides metrics for distributed training:
-
-- `train/global_batch/global_batch_size`: Effective global batch size
-- `train/global_batch/global_k_negatives`: Number of negatives per anchor globally
-- `train/global_batch/global_negatives_memory_mb`: Memory usage for global negatives
-- `train/global_batch/similarity_matrix_memory_mb`: Memory usage for similarity matrix
-- `train/global_batch/global_hard_negatives_used`: Whether global hard negatives are active
-
----
+When distributed training is active, the model gathers negatives across GPUs for richer hard-negative mining and logs memory metrics (`train/global_batch/*`) to TensorBoard.

--- a/src/naics_embedder/cli/commands/training.py
+++ b/src/naics_embedder/cli/commands/training.py
@@ -474,7 +474,15 @@ def train(
                 distance_matrix_path=cfg.data_loader.streaming.distance_matrix_parquet,
                 eval_every_n_epochs=cfg.model.eval_every_n_epochs,
                 eval_sample_size=cfg.model.eval_sample_size,
-                base_margin=cfg.loss.base_margin
+                base_margin=cfg.loss.base_margin,
+                tree_distance_alpha=cfg.curriculum.tree_distance_alpha,
+                curriculum_phase1_end=cfg.curriculum.phase1_end,
+                curriculum_phase2_end=cfg.curriculum.phase2_end,
+                curriculum_phase3_end=cfg.curriculum.phase3_end,
+                sibling_distance_threshold=cfg.curriculum.sibling_distance_threshold,
+                fn_curriculum_start_epoch=cfg.curriculum.fn_curriculum_start_epoch,
+                fn_cluster_every_n_epochs=cfg.curriculum.fn_cluster_every_n_epochs,
+                fn_num_clusters=cfg.curriculum.fn_num_clusters
             )
         
         # Setup callbacks

--- a/src/naics_embedder/text_model/naics_model.py
+++ b/src/naics_embedder/text_model/naics_model.py
@@ -158,7 +158,11 @@ class NAICSContrastiveModel(pyl.LightningModule):
         eval_every_n_epochs: int = 1,
         eval_sample_size: int = 500,
         tree_distance_alpha: float = 1.5,
-        base_margin: float = 0.5
+        base_margin: float = 0.5,
+        curriculum_phase1_end: float = 0.3,
+        curriculum_phase2_end: float = 0.7,
+        curriculum_phase3_end: float = 1.0,
+        sibling_distance_threshold: float = 2.0
     ):
         super().__init__()
         
@@ -1944,8 +1948,11 @@ class NAICSContrastiveModel(pyl.LightningModule):
             max_epochs = getattr(self.trainer, 'max_epochs', 15)
             self.curriculum_scheduler = CurriculumScheduler(
                 max_epochs=max_epochs,
+                phase1_end=getattr(self.hparams, 'curriculum_phase1_end', 0.3),
+                phase2_end=getattr(self.hparams, 'curriculum_phase2_end', 0.7),
+                phase3_end=getattr(self.hparams, 'curriculum_phase3_end', 1.0),
                 tree_distance_alpha=getattr(self.hparams, 'tree_distance_alpha', 1.5),
-                sibling_distance_threshold=2.0
+                sibling_distance_threshold=getattr(self.hparams, 'sibling_distance_threshold', 2.0)
             )
             logger.info('Curriculum scheduler initialized')
         

--- a/src/naics_embedder/tools/config_tools.py
+++ b/src/naics_embedder/tools/config_tools.py
@@ -30,7 +30,7 @@ def show_current_config(config_path: str = './conf/config.yaml'):
     
     # Load configurations
     config = load_config(config_path)
-    
+
     batch_size = config['data_loader']['batch_size']
     accumulate = config['training']['trainer']['accumulate_grad_batches']
     num_workers = config['data_loader']['num_workers']
@@ -39,7 +39,8 @@ def show_current_config(config_path: str = './conf/config.yaml'):
     warmup_steps = config['training']['warmup_steps']
     precision = config['training']['trainer']['precision']
     max_epochs = config['training']['trainer']['max_epochs']
-    
+    curriculum = config.get('curriculum', {})
+
     current_config = [
         '\n[blue]Main Configuration (conf/config.yaml):[/blue]\n',
         f'[cyan]Effective batch size:[/cyan] {batch_size * accumulate}',
@@ -53,7 +54,16 @@ def show_current_config(config_path: str = './conf/config.yaml'):
         f'  • [bold]warmup_steps:[/bold] {warmup_steps}',
         f'  • [bold]precision:[/bold] {precision}',
         f'  • [bold]max_epochs:[/bold] {max_epochs}\n',
-    ]    
+        '[cyan]Structure-Aware Dynamic Curriculum:[/cyan]',
+        f'  • [bold]phase1_end:[/bold] {curriculum.get("phase1_end", "-")} (Structural)',
+        f'  • [bold]phase2_end:[/bold] {curriculum.get("phase2_end", "-")} (Geometric)',
+        f'  • [bold]phase3_end:[/bold] {curriculum.get("phase3_end", "-")} (False Negatives)',
+        f'  • [bold]tree_distance_alpha:[/bold] {curriculum.get("tree_distance_alpha", "-")}',
+        f'  • [bold]sibling_distance_threshold:[/bold] {curriculum.get("sibling_distance_threshold", "-")}',
+        f'  • [bold]fn_curriculum_start_epoch:[/bold] {curriculum.get("fn_curriculum_start_epoch", "-")}',
+        f'  • [bold]fn_cluster_every_n_epochs:[/bold] {curriculum.get("fn_cluster_every_n_epochs", "-")}',
+        f'  • [bold]fn_num_clusters:[/bold] {curriculum.get("fn_num_clusters", "-")}\n',
+    ]
     
     console.print(
         Panel(


### PR DESCRIPTION
## Summary
- simplify the base config to a single SADC-aware curriculum block and remove hydra-style curriculum overlays
- pass curriculum scheduler settings through the config/model stack and expand the tools config output
- refresh usage and training docs to describe the dynamic SADC workflow instead of stage YAMLs

## Testing
- uv run naics-embedder tools config


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69264a958138832c9165108d4b2eb15e)